### PR TITLE
feat: add Cloudflare Pages setup template

### DIFF
--- a/cloudflare-pages-template/.github/workflows/scheduled-build.yml
+++ b/cloudflare-pages-template/.github/workflows/scheduled-build.yml
@@ -1,0 +1,39 @@
+name: Scheduled Build
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    # Runs at 00:00 UTC every day
+    - cron: '0 0 * * *'
+    # Runs at 12:00 UTC every day
+    - cron: '0 12 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.145.0'
+          extended: true
+
+      - name: Build with Hugo
+        run: ./bin/build.sh
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy public --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/cloudflare-pages-template/README.md
+++ b/cloudflare-pages-template/README.md
@@ -1,0 +1,64 @@
+# Cloudflare Pages Template
+
+This folder is a minimal example for deploying a static site (built with [Hugo](https://gohugo.io/)) to [Cloudflare Pages](https://pages.cloudflare.com) using GitHub Actions.
+
+## Repository Layout
+
+```
+.
+├── bin/
+│   └── build.sh                 # Builds the site into the public/ directory
+├── functions/
+│   └── api/                     # Cloudflare Functions used for Decap CMS auth
+│       ├── auth.js
+│       └── callback.js
+├── static/
+│   └── admin/
+│       └── main/
+│           ├── config.yml       # Decap CMS configuration
+│           └── index.html       # Decap CMS entry point
+└── .github/
+    └── workflows/
+        └── scheduled-build.yml  # GitHub Actions workflow for deployment
+```
+
+## Prerequisites
+
+* A Cloudflare account with Pages enabled
+* A GitHub repository containing your static site source
+* A GitHub OAuth application for Decap CMS (callback URL: `/api/callback`)
+* Hugo installed locally if you wish to build and test before pushing
+
+## Setup Instructions
+
+1. **Copy the template**
+   * Copy the contents of this folder into the root of your new repository.
+2. **Configure Cloudflare Pages project**
+   * Create a new Pages project in Cloudflare and connect it to your GitHub repository.
+   * Set the build command to `./bin/build.sh` (or `hugo` if using the default Hugo build) and the build output directory to `public`.
+3. **Generate a Cloudflare API token**
+   * Go to **My Profile → API Tokens → Create Token**.
+   * Use the **"Edit Cloudflare Workers"** template and grant access to your account.
+4. **Add GitHub repository secrets**
+   * In your repository settings, add the following secrets used by the workflow:
+     * `CLOUDFLARE_API_TOKEN` – the token created above
+     * `CLOUDFLARE_ACCOUNT_ID` – your Cloudflare account ID
+     * `CLOUDFLARE_PROJECT_NAME` – the Pages project name
+5. **Configure Decap CMS environment variables**
+   * In the Cloudflare Pages project settings, add the environment variables:
+     * `GITHUB_CLIENT_ID` – from your GitHub OAuth application
+     * `GITHUB_CLIENT_SECRET` – from your GitHub OAuth application
+6. **Customize build script (optional)**
+   * The `bin/build.sh` script runs `hugo build` and prints some diagnostic output. Modify it if your site uses a different build process.
+7. **Enable GitHub Actions**
+   * The workflow in `.github/workflows/scheduled-build.yml` runs on a schedule and on manual dispatch. Adjust the cron schedule or triggers as needed.
+
+## Deployment
+
+After pushing changes to your repository, you can either wait for the scheduled workflow to run or manually trigger it in the GitHub Actions tab. The workflow builds the site and deploys it to Cloudflare Pages using [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action).
+
+## Troubleshooting
+
+* Ensure the build output is written to the `public` directory.
+* Verify the required secrets are present in your GitHub repository settings.
+* Check the workflow logs in GitHub Actions for detailed error messages.

--- a/cloudflare-pages-template/bin/build.sh
+++ b/cloudflare-pages-template/bin/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Define variables
+PUBLIC_DIR="public"
+
+# Print a message
+echo "Starting the build process..."
+
+# Clean up the public directory if it exists
+if [ -d "$PUBLIC_DIR" ]; then
+  echo "Cleaning up existing public directory..."
+  rm -rf $PUBLIC_DIR
+fi
+
+
+# Run Hugo to build the site
+echo "Running Hugo..."
+
+echo "Output of hugo:"
+hugo build --buildFuture --logLevel debug
+
+echo "--------------------------------"
+
+echo "Output of hugo list published:"
+hugo list published
+
+echo "--------------------------------"
+
+echo "Output of hugo list drafts:"
+hugo list drafts
+
+echo "--------------------------------"
+
+echo "Output of hugo list future:"
+hugo list future
+
+echo "--------------------------------"
+
+echo "Output of ls -rla $PUBLIC_DIR:"
+ls -rla $PUBLIC_DIR
+
+echo "--------------------------------"
+
+# Print a success message
+echo "Build process completed successfully."

--- a/cloudflare-pages-template/functions/api/auth.js
+++ b/cloudflare-pages-template/functions/api/auth.js
@@ -1,0 +1,32 @@
+// File from https://github.com/ouroakley/netlify-cms-cloudflare-pages
+export async function onRequest(context) {
+    const {
+        request, // same as existing Worker API
+        env, // same as existing Worker API
+        params, // if filename includes [id] or [[path]]
+        waitUntil, // same as ctx.waitUntil in existing Worker API
+        next, // used for middleware or to fetch assets
+        data, // arbitrary space for passing data between middlewares
+    } = context;
+
+    const client_id = env.GITHUB_CLIENT_ID;
+
+    try {
+        const url = new URL(request.url);
+        const redirectUrl = new URL('https://github.com/login/oauth/authorize');
+        redirectUrl.searchParams.set('client_id', client_id);
+        redirectUrl.searchParams.set('redirect_uri', url.origin + '/api/callback');
+        redirectUrl.searchParams.set('scope', 'repo user');
+        redirectUrl.searchParams.set(
+            'state',
+            crypto.getRandomValues(new Uint8Array(12)).join(''),
+        );
+        return Response.redirect(redirectUrl.href, 301);
+
+    } catch (error) {
+        console.error(error);
+        return new Response(error.message, {
+            status: 500,
+        });
+    }
+}

--- a/cloudflare-pages-template/functions/api/callback.js
+++ b/cloudflare-pages-template/functions/api/callback.js
@@ -1,0 +1,79 @@
+// File from https://github.com/ouroakley/netlify-cms-cloudflare-pages
+function renderBody(status, content) {
+    const html = `
+    <script>
+      const receiveMessage = (message) => {
+        window.opener.postMessage(
+          'authorization:github:${status}:${JSON.stringify(content)}',
+          message.origin
+        );
+        window.removeEventListener("message", receiveMessage, false);
+      }
+      window.addEventListener("message", receiveMessage, false);
+      window.opener.postMessage("authorizing:github", "*");
+    </script>
+    `;
+    const blob = new Blob([html]);
+    return blob;
+}
+
+export async function onRequest(context) {
+    const {
+        request, // same as existing Worker API
+        env, // same as existing Worker API
+        params, // if filename includes [id] or [[path]]
+        waitUntil, // same as ctx.waitUntil in existing Worker API
+        next, // used for middleware or to fetch assets
+        data, // arbitrary space for passing data between middlewares
+    } = context;
+
+    const client_id = env.GITHUB_CLIENT_ID;
+    const client_secret = env.GITHUB_CLIENT_SECRET;
+
+    try {
+        const url = new URL(request.url);
+        const code = url.searchParams.get('code');
+        const response = await fetch(
+            'https://github.com/login/oauth/access_token',
+            {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    'user-agent': 'cloudflare-functions-github-oauth-login-demo',
+                    'accept': 'application/json',
+                },
+                body: JSON.stringify({ client_id, client_secret, code }),
+            },
+        );
+        const result = await response.json();
+        if (result.error) {
+            return new Response(renderBody('error', result), {
+                headers: {
+                    'content-type': 'text/html;charset=UTF-8',
+                },
+                status: 401
+            });
+        }
+        const token = result.access_token;
+        const provider = 'github';
+        const responseBody = renderBody('success', {
+            token,
+            provider,
+        });
+        return new Response(responseBody, {
+            headers: {
+                'content-type': 'text/html;charset=UTF-8',
+            },
+            status: 200
+        });
+
+    } catch (error) {
+        console.error(error);
+        return new Response(error.message, {
+            headers: {
+                'content-type': 'text/html;charset=UTF-8',
+            },
+            status: 500,
+        });
+    }
+}

--- a/cloudflare-pages-template/static/admin/main/config.yml
+++ b/cloudflare-pages-template/static/admin/main/config.yml
@@ -1,0 +1,19 @@
+backend:
+  name: github
+  repo: your-org/your-repo
+  branch: main
+  site_domain: https://example.com
+  base_url: https://example.com
+  auth_endpoint: /api/auth
+
+media_folder: "static/images/uploads"
+public_folder: "/images/uploads"
+
+collections:
+  - name: "pages"
+    label: "Pages"
+    folder: "content/pages"
+    create: true
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Body", name: "body", widget: "markdown" }

--- a/cloudflare-pages-template/static/admin/main/index.html
+++ b/cloudflare-pages-template/static/admin/main/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+</head>
+<body>
+  <!-- <script src="https://unpkg.com/decap-cms"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/decap-cms"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Cloudflare Pages deployment template for reuse
- document how to configure Cloudflare and GitHub Actions
- include basic Decap CMS setup with GitHub OAuth functions

## Testing
- `bash -n cloudflare-pages-template/bin/build.sh`
- `yamllint -c /dev/null cloudflare-pages-template/.github/workflows/scheduled-build.yml` *(fails: command not found)*
- `yamllint -c /dev/null cloudflare-pages-template/static/admin/main/config.yml` *(fails: command not found)*
- `shellcheck cloudflare-pages-template/bin/build.sh` *(fails: command not found)*
- `node --check cloudflare-pages-template/functions/api/auth.js`
- `node --check cloudflare-pages-template/functions/api/callback.js`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa3165aa008330a35b3af1b34eab55