### PR TITLE
Admin hub: show only module-backed organisers

### DIFF
--- a/.ai/organiser-cms-slugs.md
+++ b/.ai/organiser-cms-slugs.md
@@ -1,0 +1,9 @@
+# `organiser_cms_slugs` (admin hub)
+
+When you add a new organiser **Hugo module** in [`hugo.yaml`](../hugo.yaml) (`module.imports` and `static/admin/<slug>/` mounts), you must also add that **same `<slug>`** to `params.organiser_cms_slugs` in the same file.
+
+Reason: the `/admin/` listing ([`layouts/_default/admin.html`](../layouts/_default/admin.html)) cannot read `module.imports` from templates—Hugo’s `site.Config` does not expose module config—so the hub uses this explicit list to decide which taxonomy terms get a “Manage content” card.
+
+If you use [`scripts/new-organiser.sh`](../../scripts/new-organiser.sh) from the expected monorepo layout, it appends the slug for you. If you wire a module by hand, edit `organiser_cms_slugs` in the same change as the new import block.
+
+See also [`README.md`](../README.md) (Hugo modules / adding an organiser).

--- a/.ai/organiser-cms-slugs.md
+++ b/.ai/organiser-cms-slugs.md
@@ -6,4 +6,6 @@ Reason: the `/admin/` listing ([`layouts/_default/admin.html`](../layouts/_defau
 
 If you use [`scripts/new-organiser.sh`](../../scripts/new-organiser.sh) from the expected monorepo layout, it appends the slug for you. If you wire a module by hand, edit `organiser_cms_slugs` in the same change as the new import block.
 
+Only include slugs that should get a card on `/admin/`. For example, **organiser-example** mounts `static/admin/example/`, but the site uses taxonomy `example-organiser` (and it is in `ignored_organisers` on the admin page), so there is no `example` term card—`example` is omitted from the list even though the module remains in `module.imports`.
+
 See also [`README.md`](../README.md) (Hugo modules / adding an organiser).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This workspace contains multiple independent projects related to Our Oakley.
 
+At the workspace root, `AGENTS.md` is a symlink to this file (`main/AGENTS.md`). Edit **`main/AGENTS.md`** only. Longer operational notes (for example [`.ai/organiser-cms-slugs.md`](.ai/organiser-cms-slugs.md)) live under [`.ai/`](.ai/) so this guide stays short.
+
 ## Top-level directories
 
 - `main/`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Organiser content is pulled in via Hugo’s module system; dependencies are decl
 
 **Avoid:** running `go get`, `hugo mod get`, or similar and committing the result if it replaces `main` with `v0.0.0-…` pins. If tooling rewrites the file, restore the `main` lines before committing.
 
-**Adding a new organiser:** add the import mounts in `hugo.yaml`, then add one line to the `require (` block in `go.mod` with `…/organiser-<name> main // indirect` (sorted with the other organiser lines). Do not pin versions unless the project explicitly decides otherwise.
+**Adding a new organiser:** add the import mounts in `hugo.yaml`, add the same admin mount slug (the `static/admin/<slug>/` segment) to `params.organiser_cms_slugs` in `hugo.yaml` so the organiser appears on `/admin/`, then add one line to the `require (` block in `go.mod` with `…/organiser-<name> main // indirect` (sorted with the other organiser lines). Do not pin versions unless the project explicitly decides otherwise. The [`scripts/new-organiser.sh`](../scripts/new-organiser.sh) bootstrap script updates both the module block and `organiser_cms_slugs` when run from the expected monorepo layout.
 
 **`go.sum`:** listed in [.gitignore](.gitignore); do not commit it. Tooling may recreate it locally; that file stays untracked.
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -7,6 +7,31 @@ params:
   site_logo: 'images/logo.png'
   background_color_class: bg-dark-green
   body_classes: avenir bg-near-white
+  # Admin hub (/admin/): taxonomy terms must be listed here to show a CMS card. Templates
+  # cannot read module.imports (Hugo site.Config is services/privacy only). When you add an
+  # organiser module, append the static/admin/<slug>/ segment (same slug as in module mounts).
+  organiser_cms_slugs:
+    - example
+    - oakley-fc
+    - oakley-stitchers-cic
+    - oakley-wellbeing-forum
+    - oca
+    - odpc
+    - oww
+    - ramblers-wellbeing-walks-basingstoke
+    - oakley-cc
+    - the-barley-mow
+    - ojsa
+    - friends-ois
+    - the-methodist-church
+    - oakley-deane-wi
+    - oakley-bc
+    - oakley-ramblers
+    - oakley-gardening-club
+    - jolly-ollys
+    - oakley-afternoon-wi
+    - oakley-woodlands-group
+    - oakley-mens-shed
 
 taxonomies:
   venue: venues

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -11,7 +11,6 @@ params:
   # cannot read module.imports (Hugo site.Config is services/privacy only). When you add an
   # organiser module, append the static/admin/<slug>/ segment (same slug as in module mounts).
   organiser_cms_slugs:
-    - example
     - oakley-fc
     - oakley-stitchers-cic
     - oakley-wellbeing-forum

--- a/layouts/_default/admin.html
+++ b/layouts/_default/admin.html
@@ -1,4 +1,13 @@
 {{ define "main" }}
+{{ $page := . }}
+{{ $cms := site.Params.organiser_cms_slugs }}
+{{ $visible := slice }}
+{{ range .Site.Taxonomies.organisers.Alphabetical }}
+  {{ $slug := .Term }}
+  {{ if and $cms (not (in $page.Params.ignored_organisers $slug)) (in $cms $slug) }}
+    {{ $visible = $visible | append . }}
+  {{ end }}
+{{ end }}
 <div class="mw8 center ph3">
   {{ partial "breadcrumb.html" . }}
   <article class="pb6">
@@ -7,22 +16,18 @@
     </header>
 
     <div class="lh-copy">
-      {{ if .Site.Taxonomies.organisers }}
+      {{ if $visible }}
         <div class="flex flex-wrap nl3 nr3">
-          {{ range .Site.Taxonomies.organisers }}
+          {{ range $visible }}
             {{ $organiserPage := .Page }}
-            {{ with .Page.File }}
-              {{ if not (in $.Params.ignored_organisers .ContentBaseName) }}
-                <div class="w-100 w-50-m w-third-l ph3 mb4">
-                  <a href="/admin/{{ .ContentBaseName }}" class="link near-black hover-blue">
-                    <div class="pa3 bg-white br2 shadow-4 h-100">
-                      <h2 class="f4 fw6 mt0 mb2">{{ $organiserPage.Title }}</h2>
-                      <p class="f6 blue mb0">Manage Content →</p>
-                    </div>
-                  </a>
+            <div class="w-100 w-50-m w-third-l ph3 mb4">
+              <a href="/admin/{{ .Term }}" class="link near-black hover-blue">
+                <div class="pa3 bg-white br2 shadow-4 h-100">
+                  <h2 class="f4 fw6 mt0 mb2">{{ $organiserPage.Title }}</h2>
+                  <p class="f6 blue mb0">Manage Content →</p>
                 </div>
-              {{ end }}
-            {{ end }}
+              </a>
+            </div>
           {{ end }}
         </div>
       {{ else }}


### PR DESCRIPTION
## Summary
- `/admin/` organiser cards are limited to slugs listed in `params.organiser_cms_slugs` in `hugo.yaml` (templates cannot read `module.imports`).
- Taxonomy iteration uses `.Alphabetical` and `.Term` so only real organiser terms appear.
- AGENTS.md notes the root symlink and points to `.ai/`; `.ai/organiser-cms-slugs.md` documents the list.
- README documents adding the CMS slug when wiring a new organiser module.

## Test plan
- [ ] `hugo` from `main/`
- [ ] Open generated `/admin/`: cards match module-backed organisers only; main-only taxonomy terms omitted.

Made with [Cursor](https://cursor.com)